### PR TITLE
Add Flake `app` Output

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1696419054,
-        "narHash": "sha256-EdR+dIKCfqL3voZUDYwcvgRDOektQB9KbhBVcE0/3Mo=",
+        "lastModified": 1709613862,
+        "narHash": "sha256-mH+c2gFEzEe49lhUWJ0ieIaMaJ1W85E6G1xLm8ege90=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "7131f3c223a2d799568e4b278380cd9dac2b8579",
+        "rev": "311a4be96d940a0c673e88bd5bc83ea4f005cc02",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -21,13 +21,24 @@
               preCheck = ''
                 export HOME=$(mktemp -d)
               '';
-              
+
               propagatedBuildInputs = with pkgs; [
                 python3Packages.argcomplete
                 python3Packages.colorama
                 python3Packages.paramiko
                 python3Packages.pyyaml
               ];
+            };
+          });
+
+        apps = forAllSystems (system:
+          let apps = nixpkgsFor.${system}; in
+          {
+            default = self.apps.${system}.robmuxinator;
+
+            robmuxinator = {
+              type = "app";
+              program = "${self.packages.${system}.robmuxinator}/bin/robmuxinator";
             };
           });
       };


### PR DESCRIPTION
Adds an `app` output to the Nix Flake which allows running `robmuxinator` directly by referencing the Flake. Additionally, the inputs were updated.

This throws an error:
```
$ nix run github:4am-robotics/robmuxinator -- --help
error: unable to execute '/nix/store/6cq70xgca7zhwpab4kqckzz4xnbcagl2-python3.10-robmuxinator/bin/python3.10-robmuxinator': No such file or directory
```

With this feature:
```
$ nix run github:Deleh/robmuxinator/feature/flake_app -- --help
usage: robmuxinator [-h] [-c CONFIG] [-s SESSIONS] [-f] {start,stop,restart,shutdown,reboot}

robmuxinator

positional arguments:
  {start,stop,restart,shutdown,reboot}
                        which command should be executed

options:
  -h, --help            show this help message and exit
  -c CONFIG, --config CONFIG
                        the path to the yaml config file
  -s SESSIONS, --sessions SESSIONS
                        which sessions should be started/stopped
  -f, --force           close sessions even if they are locked

```