### PR TITLE
Adjust Python Shebang

### DIFF
--- a/robmuxinator/robmuxinator.py
+++ b/robmuxinator/robmuxinator.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 import argparse
 import concurrent.futures
 import logging

--- a/run.py
+++ b/run.py
@@ -1,4 +1,6 @@
-#!/usr/bin/python3
+#!/usr/bin/env python
+
 from robmuxinator.robmuxinator import main
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     main()


### PR DESCRIPTION
- Remove the redundant `robmuxinator` shebang
- Adjust the `run.py` shebang to use the `python` binary, stated in `/usr/bin/env`