### PR TITLE
[robmuxinator] fix crash after `wait_for_host` timeout

### DIFF
--- a/robmuxinator/robmuxinator.py
+++ b/robmuxinator/robmuxinator.py
@@ -304,8 +304,8 @@ class Host(object):
                 time.sleep(0.25)
                 if datetime.now() > end:
                     logger.error(
-                        "  could not connect to '{}:{}' within {} secs: {}".format(
-                            self._hostname, self._port, timeout, ex
+                        "  could not connect to '{}:{}' within {} secs".format(
+                            self._hostname, self._port, timeout
                         )
                     )
                     return False


### PR DESCRIPTION
The robmuxinator crashed if the robot is powered on an some hosts take a long time to come up. This removes the undefined variable `ex`.

```
Mai 02 07:56:53 b1 systemd[1]: Starting bringup cob...
Mai 02 07:56:53 b1 su[2267]: (to robot) root on none
Mai 02 07:56:53 b1 su[2267]: pam_unix(su-l:session): session opened for user robot by (uid=0)
Mai 02 07:56:53 b1 su[2267]: pam_unix(su-l:session): session closed for user robot
Mai 02 07:56:53 b1 cob-start[2266]: rosnode cleanup not successfull
Mai 02 07:56:53 b1 cob-start[2306]: [I] [2024-05-02 07:56:53,861]: ==================================
Mai 02 07:56:53 b1 cob-start[2306]: [I] [2024-05-02 07:56:53,861]: wait for hosts:
Mai 02 07:56:53 b1 cob-start[2306]: [I] [2024-05-02 07:56:53,862]:   waiting for PLC-WIN...
Mai 02 07:56:53 b1 cob-start[2306]: [I] [2024-05-02 07:56:53,862]:   waiting for 192.168.69.20...
Mai 02 07:57:03 b1 cob-start[2306]: [I] [2024-05-02 07:57:03,867]:   PLC-WIN is up
Mai 02 07:58:54 b1 cob-start[2306]: Traceback (most recent call last):
Mai 02 07:58:54 b1 cob-start[2306]:   File "/usr/local/bin/robmuxinator", line 8, in <module>
Mai 02 07:58:54 b1 cob-start[2306]:     sys.exit(main())
Mai 02 07:58:54 b1 cob-start[2306]:   File "/usr/local/lib/python3.8/dist-packages/robmuxinator/robmuxinator.py", line 870, in main
Mai 02 07:58:54 b1 cob-start[2306]:     if len(hosts) > 1 and not wait_for_hosts(hosts, timeout):
Mai 02 07:58:54 b1 cob-start[2306]:   File "/usr/local/lib/python3.8/dist-packages/robmuxinator/robmuxinator.py", line 554, in wait_for_hosts
Mai 02 07:58:54 b1 cob-start[2306]:     ret = ret and f.result()
Mai 02 07:58:54 b1 cob-start[2306]:   File "/usr/lib/python3.8/concurrent/futures/_base.py", line 437, in result
Mai 02 07:58:54 b1 cob-start[2306]:     return self.__get_result()
Mai 02 07:58:54 b1 cob-start[2306]:   File "/usr/lib/python3.8/concurrent/futures/_base.py", line 389, in __get_result
Mai 02 07:58:54 b1 cob-start[2306]:     raise self._exception
Mai 02 07:58:54 b1 cob-start[2306]:   File "/usr/lib/python3.8/concurrent/futures/thread.py", line 57, in run
Mai 02 07:58:54 b1 cob-start[2306]:     result = self.fn(*self.args, **self.kwargs)
Mai 02 07:58:54 b1 cob-start[2306]:   File "/usr/local/lib/python3.8/dist-packages/robmuxinator/robmuxinator.py", line 301, in wait_for_host
Mai 02 07:58:54 b1 cob-start[2306]:     self._hostname, self._port, timeout, ex
Mai 02 07:58:54 b1 cob-start[2306]: UnboundLocalError: local variable 'ex' referenced before assignment
Mai 02 07:58:54 b1 systemd[1]: cob.service: Main process exited, code=exited, status=1/FAILURE
Mai 02 07:58:54 b1 systemd[1]: cob.service: Failed with result 'exit-code'.
Mai 02 07:58:54 b1 systemd[1]: Failed to start bringup cob.

```