### PR TITLE
[log_file_exporter] adjust log format

### DIFF
--- a/robmuxinator/robmuxinator.py
+++ b/robmuxinator/robmuxinator.py
@@ -98,7 +98,7 @@ if not os.path.exists(logPath):
 logFile = "robmuxinator"
 fileHandler = RotatingFileHandler(
     "{0}/{1}.log".format(logPath, logFile), maxBytes=1024*10000, backupCount=4)
-log_formatter = logging.Formatter("[%(levelname)s] [%(asctime)s]: %(message)s")
+log_formatter = logging.Formatter("[%(levelname)s] [%(created)0.15s]: %(message)s")
 fileHandler.setFormatter(log_formatter)
 logger.addHandler(fileHandler)
 


### PR DESCRIPTION
ref https://github.com/4am-robotics/orga/issues/6690

The log_file_exporter searches for timestamps in epoch time. This had to be adjusted for the `fileHandler` since asctime is human readable.
