### PR TITLE
continue shutting down on pre command failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ sessions:
 - `command`: Choose one of the available commands (start, stop, restart, shutdown, reboot).
 - `-c` or `--config`: Specify the path to the YAML configuration file that defines the hosts, sessions, and other settings. The default configuration file path is "/etc/ros/upstart_robot.yaml."
 - `-s` or `--sessions`: Optionally, specify which sessions should be started or stopped. You can provide multiple session names as arguments.
-- `-f` or `--force`: Use this flag to force the closure of sessions, even if they are locked.
+- `-f` or `--force`: Use this flag on `stop` to close sessions that are locked. Use this flag on `shutdown` or `reboot` to ignore errors and continue shutting down or rebooting.
 - `-l <L>` or `--logging_level <L>`: Use this flag to set the logging level, ["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]
 - `--instance_id <N>`: An unique id used to prepend to each session name and used within multi-robot setups.
 

--- a/robmuxinator/robmuxinator.py
+++ b/robmuxinator/robmuxinator.py
@@ -723,7 +723,7 @@ def pre_shutdown_commands(yaml_content):
             process = subprocess.Popen(
             cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
             stdio, stderr = process.communicate()
-            if process.returncode == 0:
+            if process.returncode in [0, 1, 2]:
                 logger.info("successfully executed command: {}".format(cmd))
                 logger.info("output: {}".format(stdio))
             else:
@@ -743,7 +743,7 @@ def pre_reboot_commands(yaml_content):
             process = subprocess.Popen(
             cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
             stdio, stderr = process.communicate()
-            if process.returncode == 0:
+            if process.returncode in [0, 1, 2]:
                 logger.info("successfully executed command: {}".format(cmd))
                 logger.info("output: {}".format(stdio))
             else:

--- a/robmuxinator/robmuxinator.py
+++ b/robmuxinator/robmuxinator.py
@@ -713,7 +713,7 @@ def stop_sessions(sessions, force=False):
         )
     )
 
-def pre_shutdown_commands(yaml_content):
+def pre_shutdown_commands(yaml_content, force=False):
     logger.info("execute pre shutdown commands")
     if "pre-shutdown-commands" in yaml_content:
         for cmd in yaml_content["pre-shutdown-commands"]:
@@ -729,11 +729,12 @@ def pre_shutdown_commands(yaml_content):
             else:
                 logger.error("failed to execute command: {}".format(cmd))
                 logger.error("error: {}".format(stderr))
-                sys.exit(1)
+                if not force:
+                    sys.exit(1)
     else:
         logger.info("no pre-shutdown-commands defined")
 
-def pre_reboot_commands(yaml_content):
+def pre_reboot_commands(yaml_content, force=False):
     logger.info("execute pre reboot commands")
     if "pre-reboot-commands" in yaml_content:
         for cmd in yaml_content["pre-reboot-commands"]:
@@ -749,7 +750,8 @@ def pre_reboot_commands(yaml_content):
             else:
                 logger.error("failed to execute command: {}".format(cmd))
                 logger.error("error: {}".format(stderr))
-                sys.exit(1)
+                if not force:
+                    sys.exit(1)
     else:
         logger.info("no pre-reboot-commands defined")
 
@@ -971,11 +973,11 @@ def main():
             "restart took {} secs".format((datetime.now() - start).total_seconds())
         )
     elif command == "shutdown":
-        pre_shutdown_commands(yaml_content)
+        pre_shutdown_commands(yaml_content, args.force)
         stop_sessions(ordered_sessions_stop, True)
         shutdown_system(hosts, timeout)
     elif command == "reboot":
-        pre_reboot_commands(yaml_content)
-        pre_shutdown_commands(yaml_content)
+        pre_reboot_commands(yaml_content, args.force)
+        pre_shutdown_commands(yaml_content, args.force)
         stop_sessions(ordered_sessions_stop, True)
         shutdown_system(hosts, timeout)


### PR DESCRIPTION
ref: https://github.com/4am-robotics/orga/issues/6177

the original intention was to continue shutting down if the pre commands returned a return code of 0, 1 or 2. For example if the pre command is `rosservice call ...` but the rosmaster is not running the return code is 2 and in this case the robot shutdown should still work. For other return codes shutting down is interrupted except you add a `-f` `--force` to the `robmuxinator shutdown` command.