### PR TITLE
set instance_id default to -1 and set ENV INSTANCE_ID if instance_id >=0

### DIFF
--- a/robmuxinator/robmuxinator.py
+++ b/robmuxinator/robmuxinator.py
@@ -806,7 +806,7 @@ def main():
         "--instance_id",
         type=int,
         help="an unique id used to prepend to each session name within the config file. used for multi-robot emulation. the instance_id is also exported to the env used within the sessions as well as to guarantee a unique ROS_DOMAIN_ID",
-        default=0,
+        default=-1,
     )
 
     argcomplete.autocomplete(parser)
@@ -897,9 +897,8 @@ def main():
     # Check if 'instance_id' was given by the user.
     # This indicates the a multi-instance setup, e.g. for multi-robot emulation.
     # Therefore we export the INSTANCE_ID and use it for to guarantee a unique ROS_DOMAIN_ID
-    if instance_id != 0:
+    if instance_id >= 0:
         envs.append(("INSTANCE_ID", instance_id))
-        envs.append(("ROS_DOMAIN_ID", instance_id))
 
     # get sessions from yaml
     yaml_sessions = None
@@ -932,7 +931,7 @@ def main():
                     sessions.append(
                         Session(
                             SSHClient(user=user, hostname=hosts[host].get_hostname(), port=hosts[host].get_ssh_port()),
-                            str(instance_id) + "_" + key if instance_id != 0 else key,
+                            str(instance_id) + "_" + key if instance_id > 0 else key,
                             yaml_sessions[key],
                             envs
                         )
@@ -941,7 +940,7 @@ def main():
                 sessions.append(
                     Session(
                         SSHClient(user=user, hostname=hosts[host].get_hostname(), port=hosts[host].get_ssh_port()),
-                        str(instance_id) + "_" + key if instance_id != 0 else key,
+                        str(instance_id) + "_" + key if instance_id > 0 else key,
                         yaml_sessions[key],
                         envs
                     )


### PR DESCRIPTION
To be able to detect in dockers entrypoint if a multi robot emu is running or not, the instance_id variable should be also set for the multirobot server instances.